### PR TITLE
use global rootshell for privileged commands

### DIFF
--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -14,18 +14,18 @@ sudo apt -y install \
    can-utils \
    ffmpeg \
    iproute2 \
+   policykit-1 \
    python3-pip \
-   python3-pexpect \
    python3-pyside \
    python3.5
 
 # Pip dependencies
 sudo pip3 install --upgrade pip
-sudo pip3 install pipenv 
+sudo pip3 install pipenv
 
 # Create a new pipenv
 cd $DIR
 mkdir -p pipenv && cd pipenv
 pipenv --three
-pipenv install pyvit sphinx_rtd_theme
+pipenv install python3-pexpect pyvit sphinx_rtd_theme
 cp -rf /usr/lib/python3/dist-packages/PySide $(pipenv --venv)/lib/python3*/site-packages

--- a/install_requirements.sh
+++ b/install_requirements.sh
@@ -15,12 +15,13 @@ sudo apt -y install \
    ffmpeg \
    iproute2 \
    python3-pip \
+   python3-pexpect \
    python3-pyside \
    python3.5
 
 # Pip dependencies
 sudo pip3 install --upgrade pip
-sudo pip3 install pipenv
+sudo pip3 install pipenv 
 
 # Create a new pipenv
 cd $DIR

--- a/src/CANData.py
+++ b/src/CANData.py
@@ -30,6 +30,7 @@ import socket
 from Logger import Logger
 import Globals
 import Strings
+import Toolbox
 
 
 class CANData():
@@ -122,7 +123,7 @@ class CANData():
 
     def checkVCAN(self):
         """
-        Checks if the SocketCAN device is phyisical or virtual using a ``ls`` call to ``/sys/devices/virtual/net``.
+        Checks if the SocketCAN device is physical or virtual using a ``ls`` call to ``/sys/devices/virtual/net``.
 
         :return: A boolean value indicating if the device is virtual (True) or not (False)
         """
@@ -147,9 +148,7 @@ class CANData():
         if not self.VCAN:
             # Put interface down first so the new bitrate can be applied
             cmd = "ip link set " + self.ifaceName + " down"
-            process = subprocess.Popen(
-                cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            output, error = process.communicate()
+            output, error = Toolbox.Toolbox.runRootshell(cmd)
             # prepare cmd for next call
             cmd = "ip link set " + self.ifaceName + \
                 " up type can bitrate " + str(bitrate)
@@ -158,10 +157,7 @@ class CANData():
             cmd = "ip link set up " + self.ifaceName
 
         # Apply
-        process = subprocess.Popen(
-            cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        output, error = process.communicate()
-
+        output, error = Toolbox.Toolbox.runRootshell(cmd)
         if output.decode("utf-8") == "" and error.decode("utf-8") == "":
             if self.VCAN:
                 self.bitrate = -1

--- a/src/Globals.py
+++ b/src/Globals.py
@@ -48,3 +48,6 @@ comparerTabInstance = None
 searcherTabInstance = None
 filterTabInstance = None
 managerTabInstance = None
+
+# the rootshell to manage the CAN interfaces
+rootshell = None

--- a/src/MainTab.py
+++ b/src/MainTab.py
@@ -218,10 +218,7 @@ class MainTab:
         Load kernel modules to interact with CAN networks (``can`` and ``vcan``).
         """
 
-        cmds = '''
-            modprobe can
-            modprobe vcan
-        '''
+        cmds = "modprobe can; modprobe vcan"
         output, error = Toolbox.Toolbox.runRootshell(cmds)
 
     @staticmethod

--- a/src/MainTab.py
+++ b/src/MainTab.py
@@ -76,7 +76,7 @@ class MainTab:
     def removeApplicationStatus(status):
         """
         Remove a status from the status bar.
-        For statuses with mutiple possible values (e.g. ``Sending (X Threads)``
+        For statuses with multiple possible values (e.g. ``Sending (X Threads)``
         the search will be done using a substring search
 
         :param status: The status to remove
@@ -218,11 +218,11 @@ class MainTab:
         Load kernel modules to interact with CAN networks (``can`` and ``vcan``).
         """
 
-        cmds = ["modprobe can", "modprobe vcan"]
-        for cmd in cmds:
-            process = subprocess.Popen(
-                cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            output, error = process.communicate()
+        cmds = '''
+            modprobe can
+            modprobe vcan
+        '''
+        output, error = Toolbox.Toolbox.runRootshell(cmds)
 
     @staticmethod
     def easterEgg(event):
@@ -249,9 +249,7 @@ class MainTab:
             "ip link set up " + vifaceName
         ]
         for cmd in cmds:
-            process = subprocess.Popen(
-                cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            output, error = process.communicate()
+            output, error = Toolbox.Toolbox.runRootshell(cmd)
 
         if error is not None and error.decode("utf-8") == "":
             CANData.createCANDataInstance(vifaceName)
@@ -280,9 +278,7 @@ class MainTab:
             return
 
         cmd = "ip link delete " + vifaceName
-        process = subprocess.Popen(
-            cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        output, error = process.communicate()
+        output, error = Toolbox.Toolbox.runRootshell(cmd)
         SnifferTab.SnifferTab.removeSniffer(snifferTabName=vifaceName)
         MainTab.detectCANInterfaces()
 

--- a/src/Strings.py
+++ b/src/Strings.py
@@ -27,17 +27,18 @@ import Settings
 
 # MainTab
 mainTabLoggerName = "MainTab"
-mainTabNoSU = "No superuser privileges found, exiting"
+mainTabNoSU = "No superuser privileges found, asking"
 mainTabProjectSet = "Switched project to"
 mainTabVCANAdded = "Virtual CAN interface added:"
 mainTabVCANRemoved = "Virtual CAN interface removed:"
-mainTabMessageBoxNoSUHint = "Please run this application as root!"
+mainTabMessageBoxNoSUHint = "This application was not run as root. You will be asked for your sudo password in a moment."
 mainTabCANConfigUpdated = "CAN configuration updated"
 mainTabLogLevelChanged = "Loglevel changed"
 
 # Shared and misc
 uncaughtExceptionLoggerName = "UncaughtException"
 messageBoxErrorTitle = "Error"
+messageBoxNoticeTitle = "Notice"
 uncaughtExceptionLabel = "Uncaught exception"
 confirmDeleteMessageBoxTitle = "Confirmation"
 confirmDeleteMessageBoxText = "Are you sure you want to proceed?"
@@ -67,6 +68,7 @@ activeCANDataWontSave = "Active interface found, won't save: "
 gotSocketError = "Socket error received"
 dialogFiltering = "Filtering..."
 dialogSending = "Sending...."
+noRootshell = "No shell process with elevated privileges available."
 
 # SnifferTab
 snifferTabLoggerName = "SnifferTab"


### PR DESCRIPTION
This allows to run CANalyzat0r as regular user (without sudo). Elevated privileges
for a background shell are requested on startup in that case. This shell is reused
for all commands that require elevated privileges (e.g. changing bitrate)

This is expects pkexec from polkit to be available.

Signed-off-by: Markus S. Wamser <markus.wamser@mixed-mode.de>